### PR TITLE
Added -d delay of 30 seconds to killproc command in init scripts.

### DIFF
--- a/rpmbuild/SOURCES/rsyslog.init.epel5
+++ b/rpmbuild/SOURCES/rsyslog.init.epel5
@@ -48,7 +48,7 @@ start() {
 }
 stop() {
         echo -n $"Shutting down system logger: "
-	killproc -p "${PIDFILE}" -t30 $exec
+        killproc -p "${PIDFILE}" -d 30 $exec
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && rm -f $lockfile

--- a/rpmbuild/SOURCES/rsyslog.init.epel6
+++ b/rpmbuild/SOURCES/rsyslog.init.epel6
@@ -48,7 +48,7 @@ start() {
 }
 stop() {
         echo -n $"Shutting down system logger: "
-	killproc -p "${PIDFILE}" -t30 $exec
+        killproc -p "${PIDFILE}" -d 30 $exec
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && rm -f $lockfile


### PR DESCRIPTION
Adds a delay to 30 seconds between SIGTERM and SIGKILL after killproc has been run if the application has not shut down within the first few milliseconds of the SIGTERM. This prevents data loss when you have large queues or are persisting your queues to disk on shutdown.
