### PR TITLE
Fix version of relp module dependency librelp

### DIFF
--- a/rpmbuild/SPECS/v8-stable.spec
+++ b/rpmbuild/SPECS/v8-stable.spec
@@ -102,7 +102,7 @@ BuildRequires: postgresql-devel
 Summary: RELP protocol support for rsyslog
 Group: System Environment/Daemons
 Requires: %name = %version-%release
-Requires: librelp >= 1.2.10
+Requires: librelp >= 1.2.12
 BuildRequires: librelp-devel 
 BuildRequires: libgcrypt-devel
 


### PR DESCRIPTION
relp 8.23.0 doesn't doesn't seem to work with librelp-1.2.10. Bumping librelp to 1.2.12 fixes the issue.
Issue: #28 