### PR TITLE
Add missing Requires on libfastjson4

### DIFF
--- a/rpmbuild/SPECS/v8-stable-el7.spec
+++ b/rpmbuild/SPECS/v8-stable-el7.spec
@@ -29,6 +29,7 @@ BuildRequires: autoconf
 BuildRequires: libtool
 BuildRequires: bison
 BuildRequires: flex
+Requires: libfastjson4 >= 0.99.8
 BuildRequires: libfastjson4-devel >= 0.99.8
 BuildRequires: libestr-devel >= 0.1.9
 BuildRequires: libuuid-devel


### PR DESCRIPTION
Try to fix error:

Package: rsyslog-8.32.0-1.el7.centos.x86_64 (rsyslog8)
    Requires: libfastjson >= 0.99.8
    Available: libfastjson-0.99.0-1.el7.x86_64 (rsyslog8)
        libfastjson = 0.99.0-1.el7
    Available: libfastjson-0.99.1-1.el7.x86_64 (rsyslog8)
        libfastjson = 0.99.1-1.el7
    Available: libfastjson-0.99.2-1.el7.x86_64 (rsyslog8)
        libfastjson = 0.99.2-1.el7

But the spec seems to be for rsyslog 8.31.0-6.