### PR TITLE
Fix Dependency Error libfastjson4.

### DIFF
--- a/rpmbuild/SPECS/libfastjson4.spec
+++ b/rpmbuild/SPECS/libfastjson4.spec
@@ -4,7 +4,7 @@
 
 Name:		libfastjson4
 Version:	0.99.8
-Release:	1%{?dist}
+Release:	2%{?dist}
 Provides:	libfastjson4 = %{version}-%{release}
 Obsoletes:	libfastjson <= 0.99.6 
 Summary:	A JSON implementation in C
@@ -27,6 +27,7 @@ Summary:	Development headers and library for json-c
 Group:		Development/Libraries
 Requires:	%{name} = %{version}-%{release}
 Requires:	pkgconfig
+Obsoletes:	libfastjson-devel <= 0.99.6
 
 %description devel
 This package contains the development headers and library for libfastjson.
@@ -98,6 +99,11 @@ rm -rf %{buildroot}
 #%doc doc/html/*
 
 %changelog
+* Tue Sep 11 2018 monobaila <monobaila@users.noreply.github.com> - 0.99.8-2
+- Add obsoletes parameter to development package to fix dependency error
+  when libfastjson upgrades to libfastjson4 without instruction to remove
+  libfastjson-devel.
+
 * Mon Dec 18 2017 Florian Riedl <friedl@adiscon.com> - 0.99.8-1
 - New RPM for libfastjson4 0.99.8
 


### PR DESCRIPTION
I'm running CentOS 7.5, I was previously using rsyslog packages from the official CentOS repositories but after hitting a [bug](https://github.com/rsyslog/rsyslog/issues/2070) with omelasticsearch I'm migrating across to using the upstream rsyslog yum repository.

I hit a yum dependency error when running a "yum update" on a host when attempting to reference the new repo -

`--> Finished Dependency Resolution
Error: Package: libfastjson-devel-0.99.4-2.el7.x86_64 (@os-base)
           Requires: libfastjson(x86-64) = 0.99.4-2.el7
           Removing: libfastjson-0.99.4-2.el7.x86_64 (@os-base)
               libfastjson(x86-64) = 0.99.4-2.el7
           Obsoleted By: libfastjson4-0.99.8-1.el7.centos.x86_64 (3rdparty-rsyslog)
              ~I libfastjson4(x86-64) = 0.99.8-1.el7.centos
           Available: libfastjson-0.99.0-1.el7.x86_64 (3rdparty-rsyslog)
               libfastjson(x86-64) = 0.99.0-1.el7
           Available: libfastjson-0.99.1-1.el7.x86_64 (3rdparty-rsyslog)
               libfastjson(x86-64) = 0.99.1-1.el7
           Available: libfastjson-0.99.2-1.el7.x86_64 (3rdparty-rsyslog)
               libfastjson(x86-64) = 0.99.2-1.el7`

libfastjson4 obsoletes libfastjson but there is no obsolete instruction for the libfastjson-devel package. I've added this in the PR. I've rebuilt the package internally and this has fixed the issue for me, hopefully this fix will be useful to others.