### PR TITLE
centos8: Changed specfiles and updated mock config files

### DIFF
--- a/etc-mock/epel-6-i386.cfg
+++ b/etc-mock/epel-6-i386.cfg
@@ -5,6 +5,8 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 # beware: RHEL use 6Server or 6Client
 config_opts['releasever'] = '6'
+config_opts['use_nspawn'] = False
+config_opts['bootstrap_image'] = 'centos:6'
 
 config_opts['yum.conf'] = """
 [main]
@@ -18,6 +20,9 @@ gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=
+mdpolicy=group:primary
+best=1
+protected_packages=
 
 # repos
 [base]
@@ -25,7 +30,7 @@ name=BaseOS
 enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=6&arch=i386&repo=os
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-6
+gpgkey=http://mirror.centos.org/centos/6/os/i386/RPM-GPG-KEY-CentOS-6
 gpgcheck=1
 
 [updates]
@@ -33,14 +38,14 @@ name=updates
 enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=6&arch=i386&repo=updates
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-6
+gpgkey=http://mirror.centos.org/centos/6/os/i386/RPM-GPG-KEY-CentOS-6
 gpgcheck=1
 
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=i386
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-6
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
 gpgcheck=1
 
 [testing]

--- a/etc-mock/epel-6-x86_64.cfg
+++ b/etc-mock/epel-6-x86_64.cfg
@@ -5,6 +5,8 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 # beware RHEL use 6Server or 6Client
 config_opts['releasever'] = '6'
+config_opts['use_nspawn'] = False
+config_opts['bootstrap_image'] = 'centos:6'
 
 config_opts['yum.conf'] = """
 [main]
@@ -18,6 +20,9 @@ gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=
+mdpolicy=group:primary
+best=1
+protected_packages=
 
 # repos
 [base]
@@ -25,7 +30,7 @@ name=BaseOS
 enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=os
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-6
+gpgkey=http://mirror.centos.org/centos/6/os/x86_64/RPM-GPG-KEY-CentOS-6
 gpgcheck=1
 
 [updates]
@@ -33,14 +38,14 @@ name=updates
 enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=updates
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-6
+gpgkey=http://mirror.centos.org/centos/6/os/x86_64/RPM-GPG-KEY-CentOS-6
 gpgcheck=1
 
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-6
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
 gpgcheck=1
 
 [testing]

--- a/etc-mock/epel-7-x86_64.cfg
+++ b/etc-mock/epel-7-x86_64.cfg
@@ -4,6 +4,8 @@ config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['use_nspawn'] = False
+config_opts['bootstrap_image'] = 'centos:7'
 
 config_opts['yum.conf'] = """
 [main]
@@ -17,13 +19,16 @@ gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=
+mdpolicy=group:primary
+best=1
+protected_packages=
 
 # repos
 [base]
 name=BaseOS
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7
+gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 gpgcheck=1
 
 [updates]
@@ -31,21 +36,21 @@ name=updates
 enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7
+gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 gpgcheck=1
 
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-7
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 gpgcheck=1
 
 [extras]
 name=extras
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras
 failovermethod=priority
-gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-7
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 gpgcheck=1
 
 [testing]

--- a/etc-mock/epel-8-x86_64.cfg
+++ b/etc-mock/epel-8-x86_64.cfg
@@ -1,10 +1,13 @@
+config_opts['root'] = 'epel-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
 config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
-config_opts['package_manager'] = 'dnf'
-config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['use_nspawn'] = False
 config_opts['bootstrap_image'] = 'centos:8'
-
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+#config_opts['package_manager'] = 'dnf'
 
 config_opts['yum.conf'] = """
 [main]
@@ -27,7 +30,7 @@ module_platform_id=platform:el8
 name=CentOS-$releasever - Base
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
 failovermethod=priority
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False
 
@@ -36,14 +39,14 @@ name=CentOS-$releasever - AppStream
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=AppStream&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/AppStream/$basearch/os/
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [PowerTools]
 name=CentOS-$releasever - PowerTools
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTools&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/PowerTools/$basearch/os/
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [centosplus]
 name=CentOS-$releasever - Plus
@@ -51,21 +54,21 @@ mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=centosplu
 #baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [cr]
 name=CentOS-$releasever - cr
 baseurl=http://mirror.centos.org/centos/8/cr/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [base-debuginfo]
 name=CentOS-$releasever - Debuginfo
 baseurl=http://debuginfo.centos.org/8/$basearch/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras]
 name=CentOS-$releasever - Extras
@@ -73,7 +76,7 @@ mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=extras&in
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/os/
 gpgcheck=1
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [fasttrack]
 name=CentOS-$releasever - fasttrack
@@ -81,35 +84,35 @@ mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=fasttrack
 #baseurl=http://mirror.centos.org/centos/$releasever/fasttrack/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [BaseOS-source]
 name=CentOS-$releasever - BaseOS Sources
 baseurl=http://vault.centos.org/centos/8/BaseOS/Source/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [AppStream-source]
 name=CentOS-$releasever - AppStream Sources
 baseurl=http://vault.centos.org/centos/8/AppStream/Source/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras-source]
 name=CentOS-$releasever - Extras Sources
 baseurl=http://vault.centos.org/centos/8/extras/Source/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 
 [centosplus-source]
 name=CentOS-$releasever - Plus Sources
 baseurl=http://vault.centos.org/centos/8/centosplus/Source/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 """
 
 
@@ -120,7 +123,7 @@ config_opts['yum.conf'] += """
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=$basearch
 failovermethod=priority
-gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 gpgcheck=1
 skip_if_unavailable=False
 
@@ -150,13 +153,13 @@ skip_if_unavailable=False
 config_opts['yum.conf'] += """
 [adiscon]
 name=adiscon
-baseurl=http://rpms.adiscon.com/v8-stable/epel-7/$basearch
+baseurl=http://rpms.adiscon.com/v8-stable/epel-8/$basearch
 skip_if_unavailable=true
 enabled=1
 
 [adiscon-2]
 name=adiscon
-baseurl=http://rpms.adiscon.com/v8-stable-build/epel-7/$basearch
+baseurl=http://rpms.adiscon.com/v8-stable-build/epel-8/$basearch
 skip_if_unavailable=true
 enabled=1
 
@@ -169,8 +172,3 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=http://download.guardtime.com/ksi/GUARDTIME-GPG-KEY
 """
-
-
-config_opts['root'] = 'epel-8-x86_64'
-config_opts['target_arch'] = 'x86_64'
-config_opts['legal_host_arches'] = ('x86_64',)

--- a/rpmbuild/SPECS/liblogging.spec
+++ b/rpmbuild/SPECS/liblogging.spec
@@ -20,7 +20,7 @@ purposes via multiple channels (driver support is planned)
 Summary:	Development files for LibLogging stdlog library
 Group:		Development/Libraries
 Requires:	%{name}%{?_isa} = %{version}-%{release}
-Requires:	libee-devel%{?_isa} libestr-devel%{?_isa}
+#Requires:	libee-devel%{?_isa} libestr-devel%{?_isa}
 Requires:	pkgconfig
 
 %description devel

--- a/rpmbuild/SPECS/liblognorm5.spec
+++ b/rpmbuild/SPECS/liblognorm5.spec
@@ -15,9 +15,13 @@ BuildRoot:	%{_tmppath}/liblognorm-%{version}-%{release}-root-%(%{__id_u} -n)
 #Patch0:		liblognorm-0.3.4-rename-to-lognormalizer.patch
 #Patch1:		liblognorm-0.3.4-pc-file.patch
 BuildRequires:	libestr-devel
-BuildRequires:	libee-devel
+#BuildRequires:	libee-devel
 BuildRequires:	chrpath
-BuildRequires:  python-docutils
+%if %{?rhel} >= 8
+BuildRequires: python3-docutils
+%else
+BuildRequires: python-docutils
+%endif
 BuildRequires:	libfastjson4-devel
 
 %description
@@ -35,7 +39,7 @@ the logs you want to normalize.
 Summary:	Development tools for programs using liblognorm library
 Group:		Development/Libraries
 Requires:	%{name}%{?_isa} = %{version}-%{release}
-Requires:	libee-devel%{?_isa} libestr-devel%{?_isa}
+#Requires:	libee-devel%{?_isa} libestr-devel%{?_isa}
 Requires:	pkgconfig
 
 %description devel

--- a/rpmbuild/SPECS/librdkafka.spec
+++ b/rpmbuild/SPECS/librdkafka.spec
@@ -11,7 +11,13 @@ License: BSD-2-Clause
 URL:     https://github.com/edenhill/librdkafka
 Source:	 adisconbuild-librdkafka-%{version}.tar.gz
 
-BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ python-devel lz4-devel
+BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ lz4-devel
+%if %{?rhel} >= 8
+BuildRequires: python3-devel
+%else
+BuildRequires: python-devel
+%endif
+ 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %description

--- a/rpmbuild/SPECS/v8-stable.spec
+++ b/rpmbuild/SPECS/v8-stable.spec
@@ -29,7 +29,11 @@ Source4: %{rsysloglog}
 #Requires: libgt
 BuildRequires: libestr-devel
 BuildRequires: curl-devel
+%if %{?rhel} >= 8
+BuildRequires: python3-docutils
+%else
 BuildRequires: python-docutils
+%endif
 BuildRequires: liblogging-devel
 BuildRequires: automake
 BuildRequires: autoconf >= 2.52


### PR DESCRIPTION
Updated mock files which was needed to support newer mock versions
on Fedora 30+

For Centos8, some specfiles needed to be changed because python2 is no longer supported.

Centos8 build now successfully works. 