### PR TITLE
Update librdkafka dependency

### DIFF
--- a/rpmbuild/SPECS/librdkafka.spec
+++ b/rpmbuild/SPECS/librdkafka.spec
@@ -1,7 +1,7 @@
 Name:    adisconbuild-librdkafka
 # NOTE: Make sure to update this to match rdkafka.h version
-Version: 0.11.6
-Release: 2
+Version: 1.9.2
+Release: 1
 %define soname 1
 %define _unpackaged_files_terminate_build 0
 
@@ -88,6 +88,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Aug 25 2022 Andre Lorbach
+- Build dependency package 1.9.2
+
 * Wed Oct 31 2018 Florian Riedl
 - Re-Build dependency package 0.11.6
 

--- a/rpmbuild/SPECS/v8-stable-el7.spec
+++ b/rpmbuild/SPECS/v8-stable-el7.spec
@@ -227,7 +227,7 @@ Summary: Kafka output support
 Group: System Environment/Daemons
 Requires: %name = %version-%release
 Requires: lz4
-BuildRequires: adisconbuild-librdkafka-devel >= 0.11.6
+BuildRequires: adisconbuild-librdkafka-devel > 0.11.6
 BuildRequires: lz4-devel
 BuildRequires: cyrus-sasl-devel
 
@@ -386,7 +386,7 @@ subsequent message parsing less error-prone.
 Parser module which supports various Cisco IOS formats.
 
 %description kafka
-librdkafka is a C library implementation of the Apache Kafka protocol, 
+Includes omkafka and imkafka modules using librdkafka implementation of the Kafka protocol, 
 containing both Producer and Consumer support. It was designed with message delivery 
 reliability and high performance in mind, current figures exceed 800000 msgs/second 
 for the producer and 3 million msgs/second for the consumer.


### PR DESCRIPTION
- include source package for librdkafka.
- make sure rsyslog builds with higher librdkafka version.

closes: httpsi://github.com/rsyslog/rsyslog-pkg-rhel-centos/issues/116