### PR TITLE
Final Fix for librdkafka dependency

### DIFF
--- a/etc-mock/epel-6-i386.cfg
+++ b/etc-mock/epel-6-i386.cfg
@@ -11,6 +11,9 @@ config_opts['package_manager'] = 'yum'
 #config_opts['yum_command'] = '/usr/bin/yum-deprecated'
 #config_opts['package_manager'] = 'dnf'
 
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
+
 config_opts['yum.conf'] = """
 [main]
 keepcache=1

--- a/etc-mock/epel-6-x86_64.cfg
+++ b/etc-mock/epel-6-x86_64.cfg
@@ -11,6 +11,9 @@ config_opts['package_manager'] = 'yum'
 #config_opts['yum_command'] = '/usr/bin/yum-deprecated'
 #config_opts['package_manager'] = 'dnf'
 
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
+
 config_opts['yum.conf'] = """
 [main]
 keepcache=1

--- a/etc-mock/epel-7-x86_64.cfg
+++ b/etc-mock/epel-7-x86_64.cfg
@@ -9,8 +9,10 @@ config_opts['bootstrap_image'] = 'quay.io/centos/centos:7'
 config_opts['package_manager'] = 'yum'
 config_opts['description'] = 'CentOS 7'
 
-config_opts['yum_install_command'] += "{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %} --disablerepo=centos-sclo*{% endif %}"
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
 
+config_opts['yum_install_command'] += "{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %} --disablerepo=centos-sclo*{% endif %}"
 config_opts['yum.conf'] = """
 [main]
 keepcache=1

--- a/etc-mock/epel-8-x86_64.cfg
+++ b/etc-mock/epel-8-x86_64.cfg
@@ -9,6 +9,9 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:8'
 
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
+
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1

--- a/etc-mock/epel-9-x86_64.cfg
+++ b/etc-mock/epel-9-x86_64.cfg
@@ -8,8 +8,10 @@ config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['description'] = 'CentOS Stream 9'
-
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream9'
+
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
 
 config_opts['dnf.conf'] = """
 [main]

--- a/etc-mock/rhel-7-x86_64.cfg
+++ b/etc-mock/rhel-7-x86_64.cfg
@@ -2,8 +2,10 @@ include('templates/rhel-7.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
-
 config_opts['rhel_product'] = 'server'
+
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
 
 config_opts['yum.conf'] += """
 [adiscon]

--- a/etc-mock/rhel-8-x86_64.cfg
+++ b/etc-mock/rhel-8-x86_64.cfg
@@ -3,6 +3,9 @@ include('templates/rhel-8.tpl')
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
 
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
+
 config_opts['dnf.conf'] += """
 [adiscon]
 name=adiscon

--- a/etc-mock/rhel-9-x86_64.cfg
+++ b/etc-mock/rhel-9-x86_64.cfg
@@ -3,6 +3,9 @@ include('templates/rhel-9.tpl')
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
 
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
+
 config_opts['dnf.conf'] += """
 [adiscon]
 name=adiscon

--- a/rpmbuild/SPECS/librdkafka.spec
+++ b/rpmbuild/SPECS/librdkafka.spec
@@ -11,7 +11,7 @@ License: BSD-2-Clause
 URL:     https://github.com/edenhill/librdkafka
 Source:	 adisconbuild-librdkafka-%{version}.tar.gz
 
-BuildRequires: libtool, zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ lz4-devel
+BuildRequires: wget curl openssl-devel libcurl-devel libtool zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ cyrus-sasl-devel 
 %if %{?rhel} >= 8
 BuildRequires: python3-devel
 %else
@@ -49,7 +49,7 @@ using librdkafka.
 %prep
 %setup -q
 
-%configure --disable-hdrhistogram
+%configure --enable-static --install-deps --disable-hdrhistogram --disable-lz4-ext
 
 %build
 make


### PR DESCRIPTION
- Updated source package for librdkafka.
- Removed libzstd from "buildrequires" As it turns out we require to build the libzstd package from source ourself which is only be done if the package is NOT installed. Using --source-deps-only failed due open issues in the current librdkafka branch, so this is the best solution so far.
- updated etc-mock files to allow networking during build. This is required if we build libraries from source during make.
- With the changes above, static librdkafka libraries are build again which will solve the "undefined symbol" issues in rsyslog packages. See also: https://github.com/rsyslog/rsyslog/issues/4966

closes: https://github.com/rsyslog/rsyslog-pkg-rhel-centos/issues/116