### PR TITLE
Changed kill cmd in logrotate script

### DIFF
--- a/rpmbuild/SOURCES/rsyslog.log
+++ b/rpmbuild/SOURCES/rsyslog.log
@@ -7,6 +7,6 @@
     missingok
     sharedscripts
     postrotate
-	systemctl kill -s HUP rsyslog.service
+	/usr/bin/systemctl kill -s HUP rsyslog.service >/dev/null 2>&1 || true
     endscript
 }


### PR DESCRIPTION
Matching the EL8 / EL9 stock version of the logrotate script now.

closes: https://github.com/rsyslog/rsyslog-pkg-rhel-centos/issues/123