### PR TITLE
omazureeventhubs: Added package definiton for new output module

### DIFF
--- a/etc-mock/epel-7-x86_64.cfg
+++ b/etc-mock/epel-7-x86_64.cfg
@@ -41,28 +41,42 @@ user_agent={{ user_agent }}
 # repos
 [base]
 name=CentOS-$releasever - Base
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os
-failovermethod=priority
-gpgkey={{ centos_7_gpg_keys }}
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
 gpgcheck=1
+gpgkey={{ centos_7_gpg_keys }}
+failovermethod=priority
 skip_if_unavailable=False
 
+#released updates 
 [updates]
 name=CentOS-$releasever - Updates
-enabled=1
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates
-failovermethod=priority
-gpgkey={{ centos_7_gpg_keys }}
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
 gpgcheck=1
+gpgkey={{ centos_7_gpg_keys }}
+failovermethod=priority
 skip_if_unavailable=False
 
+#additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/os/
-failovermethod=priority
-gpgkey={{ centos_7_gpg_keys }}
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
 gpgcheck=1
+gpgkey={{ centos_7_gpg_keys }}
+failovermethod=priority
+skip_if_unavailable=False
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey={{ centos_7_gpg_keys }}
+failovermethod=priority
 skip_if_unavailable=False
 
 [fastrack]
@@ -72,14 +86,6 @@ failovermethod=priority
 gpgkey={{ centos_7_gpg_keys }}
 gpgcheck=1
 skip_if_unavailable=False
-enabled=0
-
-[centosplus]
-name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
-gpgkey={{ centos_7_gpg_keys }}
-gpgcheck=1
 enabled=0
 
 {% if target_arch == 'x86_64' %}
@@ -119,6 +125,4 @@ enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 gpgkey=https://download.guardtime.com/ksi/GUARDTIME-GPG-KEY
-
-
 """

--- a/etc-mock/epel-8-x86_64.cfg
+++ b/etc-mock/epel-8-x86_64.cfg
@@ -33,103 +33,196 @@ module_platform_id=platform:el8
 user_agent={{ user_agent }}
 
 [baseos]
-name=CentOS-$releasever - Base
-baseurl=http://vault.centos.org/centos/$releasever/BaseOS/$basearch/os/
+name=CentOS Stream $releasever - BaseOS
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False
 
 [appstream]
-name=CentOS-$releasever - AppStream
-baseurl=http://vault.centos.org/centos/$releasever/AppStream/$basearch/os/
+name=CentOS Stream $releasever - AppStream
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=AppStream&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
 gpgcheck=1
+enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[powertools]
-name=CentOS-$releasever - PowerTools
-baseurl=http://vault.centos.org/centos/$releasever/PowerTools/$basearch/os/
-gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-
-[devel]
-name=CentOS-$releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
-baseurl=http://vault.centos.org/centos/$releasever/Devel/$basearch/os/
+[debuginfo]
+name=CentOS Stream $releasever - Debuginfo
+baseurl=http://debuginfo.centos.org/$releasever-stream/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[plus]
-name=CentOS-$releasever - Plus
-baseurl=http://vault.centos.org/centos/$releasever/centosplus/$basearch/os/
+[Stream-centosplus]
+name=CentOS-Stream - Plus
+baseurl=http://mirror.centos.org/centos/$releasever-stream/centosplus/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [cr]
 name=CentOS-$releasever - cr
-baseurl=http://vault.centos.org/centos/$releasever/cr/$basearch/os/
+baseurl=http://mirror.centos.org/centos/$releasever/cr/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[debuginfo]
-name=CentOS-$releasever - Debuginfo
-baseurl=http://debuginfo.centos.org/8/$basearch/
+[Stream-base-debuginfo]
+name=CentOS-Stream - Debuginfo
+baseurl=http://debuginfo.centos.org/$releasever-stream/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras]
-name=CentOS-$releasever - Extras
-baseurl=https://vault.centos.org/centos/$releasever/extras/$basearch/os/
+name=CentOS Stream $releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever-stream/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[fasttrack]
-name=CentOS-$releasever - fasttrack
-baseurl=https://vault.centos.org/centos/$releasever/fasttrack/$basearch/os/
+[powertools]
+name=CentOS Stream $releasever - PowerTools
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=PowerTools&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[rt]
+name=CentOS Stream $releasever - RealTime
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=RT&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever-stream/RT/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[baseos-source]
-name=CentOS-$releasever - BaseOS Sources
-baseurl=http://vault.centos.org/centos/$releasever/BaseOS/Source/
+[ha]
+name=CentOS Stream $releasever - HighAvailability
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=HighAvailability&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[appstream-source]
-name=CentOS-$releasever - AppStream Sources
-baseurl=http://vault.centos.org/centos/$releasever/AppStream/Source/
+[Stream-Devel]
+name=CentOS-Stream - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
+baseurl=http://mirror.centos.org/centos/$releasever-stream/Devel/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[powertools-source]
-name=CentOS-$releasever - PowerTools Sources
-baseurl=http://vault.centos.org/centos/$releasever/PowerTools/Source/
+[Stream-BaseOS-source]
+name=CentOS-Stream - BaseOS Sources
+baseurl=http://vault.centos.org/centos/$releasever-stream/BaseOS/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[extras-source]
-name=CentOS-$releasever - Extras Sources
-baseurl=http://vault.centos.org/centos/$releasever/extras/Source/
+[Stream-AppStream-source]
+name=CentOS-Stream - AppStream Sources
+baseurl=http://vault.centos.org/centos/$releasever-stream/AppStream/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[splus-source]
-name=CentOS-$releasever - Plus Sources
-baseurl=http://vault.centos.org/centos/$releasever/centosplus/Source/
+[Stream-PowerTools-source]
+name=CentOS-Stream - PowerTools Sources
+baseurl=http://vault.centos.org/centos/$releasever-stream/PowerTools/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[Stream-extras-source]
+name=CentOS-Stream - Extras Sources
+baseurl=http://vault.centos.org/centos/$releasever-stream/extras/Source/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[Stream-centosplus-source]
+name=CentOS-Stream - Plus Sources
+baseurl=http://vault.centos.org/centos/$releasever-stream/centosplus/Source/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[epel]
+name=Extra Packages for Enterprise Linux $releasever - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-debug-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-source]
+name=Extra Packages for Enterprise Linux $releasever - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-source-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-testing]
+name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-epel$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-testing-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-testing-source]
+name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-modular]
+name=Extra Packages for Enterprise Linux Modular $releasever - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-modular-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-modular-debuginfo]
+name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-modular-debug-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-modular-source]
+name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-modular-source-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
 """
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [adiscon]
 name=adiscon
 baseurl=http://rpms.adiscon.com/v8-stable/epel-8/$basearch

--- a/etc-mock/epel-9-x86_64.cfg
+++ b/etc-mock/epel-9-x86_64.cfg
@@ -110,9 +110,113 @@ gpgcheck=1
 enabled=1
 skip_if_unavailable=False
 
+[epel]
+name=Extra Packages for Enterprise Linux $releasever - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-debug-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-source]
+name=Extra Packages for Enterprise Linux $releasever - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-source-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-testing]
+name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-epel$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-testing-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-testing-source]
+name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
 """
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
+
+[epel-next]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-$releasever&arch=$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-debug-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-source]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-source-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-testing]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-testing-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-debug-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-testing-source]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-source-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[local]
+name=Extra Packages for Enterprise Linux $releasever - Next - Koji Local - BUILDROOT ONLY!
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-next-build/latest/$basearch/
+cost=2000
+enabled=0
+skip_if_unavailable=False
+"""
+
+config_opts['dnf.conf'] += """
 [adiscon]
 name=adiscon
 baseurl=http://rpms.adiscon.com/v8-stable/epel-9/$basearch

--- a/etc-mock/rhel-8-x86_64.cfg
+++ b/etc-mock/rhel-8-x86_64.cfg
@@ -2,6 +2,7 @@ include('templates/rhel-8.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] += ' tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
 
 config_opts['rpmbuild_networking'] = True
 config_opts['use_host_resolv'] = True

--- a/etc-mock/rhel-9-x86_64.cfg
+++ b/etc-mock/rhel-9-x86_64.cfg
@@ -2,6 +2,7 @@ include('templates/rhel-9.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] += ' tar redhat-rpm-config redhat-release which xz sed make bzip2 gzip coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep glibc-minimal-langpack'
 
 config_opts['rpmbuild_networking'] = True
 config_opts['use_host_resolv'] = True


### PR DESCRIPTION
- Added new dependencies for proton packages into mock config files
- build and install cmake ourself needed to build qpid-proton on EPEL7 and EPEL8
- build and install qpid-proton ourself with static libraries enabled on RHEL 7, RHEL 8 and RHEL9.
- build omazureeventhubs module with static linked qpid-proton to remove system library dependency (too old version installed or proactor missing).
- Added extra packages into mock config files.