### PR TITLE
fix: improve Sphinx documentation build process in v8-stable-el7.spec

### DIFF
--- a/rpmbuild/SPECS/v8-stable-el7.spec
+++ b/rpmbuild/SPECS/v8-stable-el7.spec
@@ -519,12 +519,14 @@ ls -al ./ 2>&1 | tee /dev/stderr
 mv doc _doc
 cd _doc
 
-echo "Step 1: Installing pip requirements..."
+echo "Step 1: Installing sphinx via pip..."
+pip3 install -U sphinx
+echo "Step 1.1: Installing pip requirements..."
 pip3 install -r requirements.txt 2>&1
 
 # Step 2: Build Sphinx documentation
 echo "Step 2: Building Sphinx documentation..."
-make html 2>&1
+sphinx-build -b html source build 2>&1
 echo "✓ Sphinx documentation built"
 
 # Step 3: List build directory contents


### PR DESCRIPTION
## Fix Sphinx Documentation Build Process

### Changes
This PR improves the Sphinx documentation build process in the v8-stable-el7.spec file:

1. **Explicit Sphinx Installation**: Added `pip3 install -U sphinx` before installing requirements to ensure Sphinx is available
2. **Direct Sphinx Build**: Replaced `make html` with `sphinx-build -b html source build` for more explicit control over the build process
3. **Improved Step Messaging**: Updated step numbering and messages for better clarity during the build process

### Why These Changes?
- The previous approach relied on `make html` which might not work consistently across different environments
- Explicit sphinx installation ensures the required tool is available before attempting to build documentation
- Direct sphinx-build command provides better error reporting and control over the build process
