### PR TITLE
fix: correct documentation build directory structure in v8-stable-el7…

### DIFF
--- a/rpmbuild/SPECS/v8-stable-el7.spec
+++ b/rpmbuild/SPECS/v8-stable-el7.spec
@@ -532,12 +532,13 @@ echo "✓ Sphinx documentation built"
 # Step 3: List build directory contents
 echo "Step 3: Listing build directory contents..."
 ls -al 2>&1
+ls -al build 2>&1
 echo "✓ Directory contents listed"
 
 # Step 4: Copy to doc
 echo "Step 4: Move build html files doc"
 cd ..
-mv _doc/build/html doc
+mv _doc/build doc
 
 # Step 5: Cleanup doc buildfiles
 # rm -rf %{buildroot}/_doc


### PR DESCRIPTION
## Fix Documentation Build Directory Structure

### Summary
This PR fixes an issue in the `v8-stable-el7.spec` file where the documentation build process was incorrectly moving only the `html` subdirectory instead of the entire `build` directory.

### Changes Made
- **Added debugging output**: Added `ls -al build 2>&1` command to list build directory contents for better debugging visibility
- **Fixed directory move operation**: Changed `mv _doc/build/html doc` to `mv _doc/build doc` to move the entire build directory structure

### Problem
The previous implementation was only moving the `html` subdirectory from the build output, which could result in incomplete documentation structure being copied to the final RPM package.

### Solution
By moving the entire `build` directory, we ensure that all documentation artifacts (including any additional files, assets, or subdirectories) are properly included in the final package.
