### PR TITLE
Rename plugin from mmsnarewinsec to mmsnareparse

### DIFF
--- a/rpmbuild/SPECS/v8-stable-el7.spec
+++ b/rpmbuild/SPECS/v8-stable-el7.spec
@@ -250,7 +250,7 @@ BuildRequires: adisconbuild-librdkafka-devel > 0.11.6
 BuildRequires: lz4-devel
 BuildRequires: cyrus-sasl-devel
 
-%package mmsnarewinsec
+%package mmsnareparse
 Summary: NXLog Snare Windows Security event parser support
 Group: System Environment/Daemons
 Requires: %name = %version-%release
@@ -434,8 +434,8 @@ containing both Producer and Consumer support. It was designed with message deli
 reliability and high performance in mind, current figures exceed 800000 msgs/second 
 for the producer and 3 million msgs/second for the consumer.
 
-%description mmsnarewinsec
-The mmsnarewinsec module parses NXLog Snare-formatted Windows Security events
+%description mmsnareparse
+The mmsnareparse module parses NXLog Snare-formatted Windows Security events
 that are embedded in RFC3164/RFC5424 syslog envelopes or delivered as JSON
 payloads. Incoming events are normalized and attached to the rsyslog message
 as a JSON representation that mirrors the structure documented by NXLog and Snare.
@@ -651,7 +651,7 @@ export HIREDIS_LIBS=-L%{_libdir}
 	--enable-mmdblookup \
 	--enable-pmnormalize \
 	--enable-omazureeventhubs \
-	--enable-mmsnarewinsec \
+	--enable-mmsnareparse \
 	--enable-qpidproton-static \
 	--enable-debug-symbols
 #	--enable-pmrfc3164sd \
@@ -889,9 +889,9 @@ done
 %{_libdir}/rsyslog/omkafka.so
 %{_libdir}/rsyslog/imkafka.so
 
-%files mmsnarewinsec
+%files mmsnareparse
 %defattr(-,root,root)
-%{_libdir}/rsyslog/mmsnarewinsec.so
+%{_libdir}/rsyslog/mmsnareparse.so
 
 %if %{?rhel} >= 8
 %files dtls
@@ -941,7 +941,7 @@ done
 
 %changelog
 * Wed Oct 01 2025 Andre Lorbach - 8.2506.0-2
-- Added package definition for mmmsnarewinsec.
+- Added package definition for mmsnareparse.
 
 * Tue Jun 10 2025 Florian Riedl - 8.2506.0-1
 - Release build for 8.2506.0


### PR DESCRIPTION
Update package definition, description, configure flag, files section, shared object file, and changelog to use new plugin name.